### PR TITLE
Improve the docstring for the private method _is_ansys_var().

### DIFF
--- a/src/ansys/tools/report.py
+++ b/src/ansys/tools/report.py
@@ -180,7 +180,7 @@ class Report(scooby.Report):
         Returns
         -------
         bool
-            True if the environment variable belongs to this set.
+            ``True`` when successful, ``False`` when failed.
         """
         # Loop over the Ansys default variables prefixes
         for prefix in __ANSYS_VARS_PREFIX__:


### PR DESCRIPTION
Mention all the possible returned value for the private method named: `_is_ansys_var`.